### PR TITLE
v3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Change Log 
 ==========
+* __3.1.1__ (2021-12-16):
+    * fixed regressions (issues 24, 27; residual error reporting, cancel button)
+    * progress bar now more fine-grained
 * __3.1.0__ (2021-12-10):
     * fix issues 22, 23 (segfaults on QGIS>=3.20, on MacOS and Windows)
     * new: processing toolbox algorithm

--- a/metadata.txt
+++ b/metadata.txt
@@ -1,6 +1,6 @@
 [general]
 name=cartogram3
-version=3.1.0
+version=3.1.1
 hasProcessingProvider=yes
 
 category=Vector
@@ -24,6 +24,9 @@ qgisMinimumVersion=3.16.12
 qgisMaximumVersion=3.99
 
 changelog=
+    3.1.1 (2021-12-16):
+        - fixed regressions (issues 24, 27; residual error reporting, cancel button)
+        - progress bar now more fine-grained
     3.1.0 (2021-12-10):
         - fix issues 22, 23 (segfaults on QGIS>=3.20, on MacOS and Windows)
         - new: processing toolbox algorithm


### PR DESCRIPTION
* __3.1.1__ (2021-12-16):
    * fixed regressions (issues 24, 27; residual error reporting, cancel button)
    * progress bar now more fine-grained
